### PR TITLE
Thêm tính năng phân trang cho danh sách Group

### DIFF
--- a/MBS.Application/Models/Groups/GroupModel.cs
+++ b/MBS.Application/Models/Groups/GroupModel.cs
@@ -15,9 +15,8 @@ namespace MBS.Application.Models.Groups
 
     public class GroupResponseDTO
     {
-        public string Name { get; set; }
+        public string ProjectName { get; set; }
         public string StudentName { get; set; }
-
         public string PositionName { get; set; }
     }
 

--- a/MBS.Application/Models/Groups/GroupModel.cs
+++ b/MBS.Application/Models/Groups/GroupModel.cs
@@ -15,10 +15,10 @@ namespace MBS.Application.Models.Groups
 
     public class GroupResponseDTO
     {
-        public Guid ProjectId { get; set; }
-        public string StudentId { get; set; }
-        
-        public Guid PositionId { get; set; }
+        public string Name { get; set; }
+        public string StudentName { get; set; }
+
+        public string PositionName { get; set; }
     }
 
 }

--- a/MBS.DataAccess/Repositories/Implements/GroupRepository.cs
+++ b/MBS.DataAccess/Repositories/Implements/GroupRepository.cs
@@ -28,4 +28,15 @@ public class GroupRepository(IBaseDAO<Group> dao) : BaseRepository<Group>(dao), 
         );
     }
 
+    public async Task<Pagination<Group>> GetPagedListBaseAsync(int page, int size)
+    {
+        return await _dao.GetPagingListAsync
+            (
+                include: p => p.Include(
+                    x => x.Project).Include(y => y.Student).Include(z => z.Position)
+                );
+    }
+
+
+
 }

--- a/MBS.DataAccess/Repositories/Interfaces/IGroupRepository.cs
+++ b/MBS.DataAccess/Repositories/Interfaces/IGroupRepository.cs
@@ -9,5 +9,7 @@ public interface IGroupRepository : IBaseRepository<Group>
         Task<IEnumerable<Group>> GetGroupByProjectIdAsync(Guid projectId);
         Task<Pagination<Group>> GetGroupsByStudentId(string studentId, int page, int size, string sortOrder);
 
+    Task<Pagination<Group>> GetPagedListBaseAsync(int page, int size);
+
 }
 


### PR DESCRIPTION
Thêm tính năng phân trang vào API lấy danh sách Group để cải thiện hiệu suất và giảm tải dữ liệu.
Chuyển đổi các đối tượng Group lấy được từ cơ sở dữ liệu thành GroupResponseDTO để chỉ lấy các trường cần thiết (ProjectName, StudentName, và PositionName).
Thay đổi này nhằm mục tiêu:
Giảm lượng dữ liệu không cần thiết trong phản hồi API.
Tăng tốc độ tải dữ liệu và trải nghiệm người dùng khi phân trang.
Các thay đổi chính
<!-- Liệt kê chi tiết các thay đổi chính trong pull request -->
 Repository: Cập nhật GetPagedListBaseAsync trong GroupRepository để lấy danh sách Group đã phân trang và bao gồm các thuộc tính liên quan (Project, Student, và Position).
 Service: Thêm phương thức GetGroups trong lớp service để chuyển đổi Pagination<Group> sang Pagination<GroupResponseDTO>.
 DTO Mapping: Sử dụng vòng lặp để chuyển đổi từng đối tượng Group thành GroupResponseDTO với các trường cần thiết (ProjectName, StudentName, và PositionName).
 Pagination: Tạo đối tượng Pagination<GroupResponseDTO> để trả về danh sách dữ liệu phân trang theo các yêu cầu từ client.
 Response: Cập nhật đối tượng BaseModel<Pagination<GroupResponseDTO>> để chuẩn hóa phản hồi API.